### PR TITLE
Improve type safety of object model

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ chrono = { version = "0.4", features = ["serde"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+serde_repr = "0.1"
 thiserror = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "sync"] }
 tracing = "0.1"


### PR DESCRIPTION
Introduces a LogDestination algebraic enum for type-safe serialization. The previous model allowed ALL identifying fields to be empty, or conflicting sets of fields to be present. This change ensures exactly one complete set of the necessary fields are present. It also allows differentiating the generalized Logs3Row types with more certainty.

Additionally, I have ensured SpanObjectType is used end-to-end for the object_type of FullSpan, eliminating the need for the TryFrom.

I also marked the internal data model types as `pub(crate)` so we don't accidentally expose them unintentionally.