### PR TITLE
Avoid unnecessary allocations

### DIFF
--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -60,12 +60,12 @@ impl MockBraintrustClient {
 impl SpanSubmitter for MockBraintrustClient {
     async fn submit(
         &self,
-        token: String,
+        token: impl Into<String> + Send,
         payload: SpanPayload,
         parent_info: Option<ParentSpanInfo>,
     ) -> Result<()> {
         self.collector.push(CapturedSpan {
-            token,
+            token: token.into(),
             payload,
             parent: parent_info,
         });
@@ -73,13 +73,13 @@ impl SpanSubmitter for MockBraintrustClient {
     }
 }
 
-pub(crate) fn mock_span_builder() -> (SpanBuilder, TestSpanCollector) {
+pub(crate) fn mock_span_builder() -> (SpanBuilder<MockBraintrustClient>, TestSpanCollector) {
     let (submitter, collector) = MockBraintrustClient::new();
     let builder = SpanBuilder::new(submitter, "test-token", "org-id");
     (builder, collector)
 }
 
-pub(crate) fn build_test_span() -> (SpanHandle, TestSpanCollector) {
+pub(crate) fn build_test_span() -> (SpanHandle<MockBraintrustClient>, TestSpanCollector) {
     let (builder, collector) = mock_span_builder();
     (builder.build(), collector)
 }


### PR DESCRIPTION
Pass around `impl Into<String>` to avoid copying, which also required eliminating the dynamic dispatch of `dyn Trait`. This allows avoiding allocation of strings until absolutely necessary, and the avoidance of dynamic dispatch is a nice bonus for performance.