### PR TITLE
Avoid untyped serde

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,10 @@ pub use error::{BraintrustError, Result};
 pub use extractors::{extract_anthropic_usage, extract_openai_usage};
 pub use logger::{BraintrustClient, BraintrustClientConfig};
 pub use span::{SpanBuilder, SpanHandle, SpanLog};
-pub use stream::{wrap_stream_with_span, BraintrustStream, FinalizedStream};
+pub use stream::{
+    wrap_stream_with_span, BraintrustStream, ChatMessage, FinalizedStream, FunctionCall,
+    OutputChoice, StreamMetadata, ToolCall,
+};
 pub use types::{
-    CompletionTokensDetails, ParentSpanInfo, PromptTokensDetails, Usage, UsageMetrics,
+    CompletionTokensDetails, ParentSpanInfo, PromptTokensDetails, SpanType, Usage, UsageMetrics,
 };


### PR DESCRIPTION
This replaces the use of serde_json::Map with concrete types with extras maps where needed so we can at least make things partially-typed wherever we are certain of the shapes. It also serves to clarify the data model for future evolution.