### PR TITLE
Adds proper separation between data plane and control plane URLs, aligning with how the TypeScript/Python SDKs handle `api_url` vs `app_url`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "braintrust-sdk-rust"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 edition = "2021"
 rust-version = "1.86.0"
 authors = ["Braintrust Team <team@braintrust.dev>"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,6 @@ pub use stream::{
     OutputChoice, StreamMetadata, ToolCall,
 };
 pub use types::{
-    CompletionTokensDetails, ParentSpanInfo, PromptTokensDetails, SpanObjectType, SpanType, Usage,
-    UsageMetrics,
+    CompletionTokensDetails, InvalidSpanObjectType, ParentSpanInfo, PromptTokensDetails,
+    SpanObjectType, SpanType, Usage, UsageMetrics,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,5 +16,6 @@ pub use stream::{
     OutputChoice, StreamMetadata, ToolCall,
 };
 pub use types::{
-    CompletionTokensDetails, ParentSpanInfo, PromptTokensDetails, SpanType, Usage, UsageMetrics,
+    CompletionTokensDetails, ParentSpanInfo, PromptTokensDetails, SpanObjectType, SpanType, Usage,
+    UsageMetrics,
 };

--- a/src/types.rs
+++ b/src/types.rs
@@ -33,6 +33,19 @@ impl fmt::Display for SpanObjectType {
     }
 }
 
+impl TryFrom<u8> for SpanObjectType {
+    type Error = ();
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            1 => Ok(SpanObjectType::Experiment),
+            2 => Ok(SpanObjectType::ProjectLogs),
+            3 => Ok(SpanObjectType::PlaygroundLogs),
+            _ => Err(()),
+        }
+    }
+}
+
 /// The type of span.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -484,7 +497,7 @@ mod tests {
     }
 
     #[test]
-    fn parent_span_info_full_span_uses_typed_object_type() {
+    fn parent_span_info_full_span_serializes_object_type_as_u8() {
         let parent = ParentSpanInfo::FullSpan {
             object_type: SpanObjectType::Experiment,
             object_id: "exp-123".to_string(),
@@ -495,13 +508,13 @@ mod tests {
         let json = serde_json::to_value(&parent).unwrap();
         let obj = json.get("FullSpan").unwrap();
 
-        // SpanObjectType should serialize as u8 for wire compatibility
+        // SpanObjectType serializes as u8 for wire compatibility
         assert_eq!(obj.get("object_type").unwrap(), 1);
     }
 
     #[test]
     fn parent_span_info_deserializes_with_typed_object_type() {
-        // SpanObjectType deserializes from integer (wire format)
+        // Deserializes from integer (wire format) into SpanObjectType
         let json = json!({
             "FullSpan": {
                 "object_type": 1,
@@ -551,6 +564,18 @@ mod tests {
 
         let result: Result<ParentSpanInfo, _> = serde_json::from_value(json);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn span_object_type_try_from_u8() {
+        assert_eq!(SpanObjectType::try_from(1), Ok(SpanObjectType::Experiment));
+        assert_eq!(SpanObjectType::try_from(2), Ok(SpanObjectType::ProjectLogs));
+        assert_eq!(
+            SpanObjectType::try_from(3),
+            Ok(SpanObjectType::PlaygroundLogs)
+        );
+        assert!(SpanObjectType::try_from(0).is_err());
+        assert!(SpanObjectType::try_from(99).is_err());
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -586,14 +586,8 @@ mod tests {
             SpanObjectType::try_from(3),
             Ok(SpanObjectType::PlaygroundLogs)
         );
-        assert_eq!(
-            SpanObjectType::try_from(0),
-            Err(InvalidSpanObjectType(0))
-        );
-        assert_eq!(
-            SpanObjectType::try_from(99),
-            Err(InvalidSpanObjectType(99))
-        );
+        assert_eq!(SpanObjectType::try_from(0), Err(InvalidSpanObjectType(0)));
+        assert_eq!(SpanObjectType::try_from(99), Err(InvalidSpanObjectType(99)));
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -33,15 +33,27 @@ impl fmt::Display for SpanObjectType {
     }
 }
 
+/// Error returned when an invalid u8 value is converted to SpanObjectType.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct InvalidSpanObjectType(pub u8);
+
+impl fmt::Display for InvalidSpanObjectType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "invalid SpanObjectType value: {}", self.0)
+    }
+}
+
+impl std::error::Error for InvalidSpanObjectType {}
+
 impl TryFrom<u8> for SpanObjectType {
-    type Error = ();
+    type Error = InvalidSpanObjectType;
 
     fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
             1 => Ok(SpanObjectType::Experiment),
             2 => Ok(SpanObjectType::ProjectLogs),
             3 => Ok(SpanObjectType::PlaygroundLogs),
-            _ => Err(()),
+            _ => Err(InvalidSpanObjectType(value)),
         }
     }
 }
@@ -574,8 +586,14 @@ mod tests {
             SpanObjectType::try_from(3),
             Ok(SpanObjectType::PlaygroundLogs)
         );
-        assert!(SpanObjectType::try_from(0).is_err());
-        assert!(SpanObjectType::try_from(99).is_err());
+        assert_eq!(
+            SpanObjectType::try_from(0),
+            Err(InvalidSpanObjectType(0))
+        );
+        assert_eq!(
+            SpanObjectType::try_from(99),
+            Err(InvalidSpanObjectType(99))
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds proper separation between data plane and control plane URLs, aligning with how the TypeScript/Python SDKs handle `api_url` vs `app_url`.

## Changes

### Data plane / control plane separation

The worker now routes requests to the appropriate URL:

- **`api_url`** (data plane): `/logs3` endpoint for submitting spans
- **`app_url`** (control plane): `/api/project/register`, `/api/apikey/login`

This matches the behavior of the TypeScript SDK where `api_url` is derived from the login response and used specifically for data ingestion, while `app_url` is used for control plane operations.

### Export `SpanObjectType` with `TryFrom<u8>`

- `SpanObjectType` is now public, allowing consumers (like the gateway) to use type-safe enum matching instead of magic numbers
- Added `TryFrom<u8>` implementation for converting from wire format

### Testing

Added `separate_urls_for_data_and_control_plane` test that uses two separate mock servers to verify:
- `/logs3` requests go to `api_url` only
- `/api/project/register` requests go to `app_url` only

## Motivation

This change enables the Braintrust gateway to use this SDK with separate data plane and control plane endpoints, which is required for proper production deployments where these services may be hosted at different URLs.