### PR TITLE
Skip login when creating braintrust client

### DIFF
--- a/src/span.rs
+++ b/src/span.rs
@@ -208,6 +208,7 @@ pub(crate) trait SpanSubmitter: Send + Sync {
     ) -> Result<()>;
 }
 
+#[derive(Debug)]
 #[allow(private_bounds)]
 pub struct SpanBuilder<S: SpanSubmitter> {
     submitter: Arc<S>,


### PR DESCRIPTION
This is for when u want to call `span_handle_with_credentials` and don't want to specify credentials upfront (cases where your application uses more than 1 `BRAINTRUST_API_KEY`