### PR TITLE
Feature gating the eval module in order to allow for cross-platform builds

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 mod dataset;
 mod error;
+#[cfg(unix)]
 pub mod eval;
 mod experiments;
 mod extractors;


### PR DESCRIPTION
Current work in the evals module is unix native. 

Since we're not exposing the feature for windows builds of the cli currently i figure this is an easy update and later reversion once bt eval for windows is live.

bt cli windows builds fail due to this lack of feature gating, blocking a canary release in general based on our current build rules:

[error from a failing build in a downstream PR for braintrustdata/bt](https://github.com/braintrustdata/bt/actions/runs/23214598059/job/68215721528): 

```
error[E0433]: failed to resolve: could not find `unix` in `os`
   --> C:\Users\runneradmin\.cargo\git\checkouts\braintrust-sdk-rust-69f0578a88a37bd0\6330e78\src\eval\bt_runner.rs:131:28
    |
131 |             match std::os::unix::net::UnixStream::connect(&sock_path) {
    |                            ^^^^ could not find `unix` in `os`
    |
note: found an item that was configured out
   --> /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf\library\std\src\os\mod.rs:29:5
    |
    = note: the item is gated here
note: found an item that was configured out
   --> /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf\library\std\src\os\mod.rs:84:41
    |
    = note: the item is gated here

For more information about this error, try `rustc --explain E0433`.
error: could not compile `braintrust-sdk-rust` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
  × failed to find bin bt.exe for path+file:///D:/a/bt/bt#0.2.0
  help: did the above build fail?`
  ```