### PR TITLE
Propagate inherited fields properly

### DIFF
--- a/src/dataset.rs
+++ b/src/dataset.rs
@@ -741,6 +741,7 @@ impl<S: SpanSubmitter + DatasetRegistrar + DatasetFetcher + DatasetSummarizer + 
                 } else {
                     None
                 },
+                extra: std::collections::HashMap::new(),
             };
 
             let parent_info = ParentSpanInfo::Dataset {

--- a/src/experiments/experiment.rs
+++ b/src/experiments/experiment.rs
@@ -198,6 +198,7 @@ impl<
             tags: feedback.tags,
             context: None,
             span_attributes: None,
+            extra: HashMap::new(),
         };
 
         let parent_info = ParentSpanInfo::Experiment {
@@ -384,6 +385,7 @@ impl<
                 purpose: None,
                 extra: HashMap::new(),
             }),
+            extra: HashMap::new(),
         };
 
         let parent_info = ParentSpanInfo::Experiment {

--- a/src/log_queue/merge.rs
+++ b/src/log_queue/merge.rs
@@ -185,6 +185,15 @@ pub(crate) fn merge_row_into(target: &mut Logs3Row, source: Logs3Row) {
         }
     }
 
+    for (key, source_value) in source.extra {
+        match target.extra.get_mut(&key) {
+            Some(target_value) => deep_merge(target_value, &source_value),
+            None => {
+                target.extra.insert(key, source_value);
+            }
+        }
+    }
+
     // Combine merge_paths from both entries.
     // Only retain merge paths if both entries are merge-type entries.
     let final_is_merge = target.is_merge.unwrap_or(false) && source.is_merge.unwrap_or(false);

--- a/src/log_queue/queue.rs
+++ b/src/log_queue/queue.rs
@@ -12,7 +12,10 @@ use super::row_key::RowKey;
 use super::worker::LogCommand;
 use crate::error::{BraintrustError, Result};
 use crate::logger::LoginState;
-use crate::types::{LogDestination, Logs3Row, ParentSpanInfo, SpanObjectType, SpanPayload};
+use crate::types::{
+    LogDestination, Logs3Row, ParentSpanInfo, SpanObjectType, SpanPayload,
+    INTERNAL_OVERRIDE_PAGINATION_KEY_FIELD,
+};
 use arc_swap::ArcSwap;
 use crossbeam::channel::{bounded, unbounded, Receiver, Sender, TrySendError};
 use futures::future::join_all;
@@ -381,6 +384,8 @@ impl LogQueueCore {
             span_attributes,
         } = payload;
 
+        let extra = inherited_logs3_extra(span_components.as_ref(), parent_info.as_ref());
+
         if let Some(span_components) = span_components {
             let destination = self
                 .destination_from_span_components(
@@ -415,7 +420,7 @@ impl LogQueueCore {
                 tags,
                 context,
                 span_attributes,
-                extra: HashMap::new(),
+                extra,
                 created: Utc::now(),
                 xact_id: None,
                 object_delete: None,
@@ -539,7 +544,7 @@ impl LogQueueCore {
             tags,
             context,
             span_attributes,
-            extra: HashMap::new(),
+            extra,
             created: Utc::now(),
             xact_id: None,
             object_delete: None,
@@ -731,6 +736,7 @@ impl LogQueueCore {
             } = cmd;
 
             let span_components = payload.span_components.clone();
+            let extra = inherited_logs3_extra(span_components.as_ref(), parent_info.as_ref());
 
             let span_id = payload.span_id.clone();
             let destination = match span_components.as_ref() {
@@ -821,7 +827,7 @@ impl LogQueueCore {
                 tags: payload.tags,
                 context: payload.context,
                 span_attributes: payload.span_attributes,
-                extra: HashMap::new(),
+                extra,
                 created: Utc::now(),
                 xact_id: None,
                 object_delete: None,
@@ -845,6 +851,32 @@ impl LogQueueCore {
             }
         });
     }
+}
+
+fn inherited_logs3_extra(
+    span_components: Option<&crate::span_components::SpanComponents>,
+    parent_info: Option<&ParentSpanInfo>,
+) -> HashMap<String, Value> {
+    let propagated_event = span_components
+        .and_then(|components| components.propagated_event.as_ref())
+        .or_else(|| match parent_info {
+            Some(ParentSpanInfo::FullSpan {
+                propagated_event: Some(propagated_event),
+                ..
+            }) => Some(propagated_event),
+            _ => None,
+        });
+
+    let mut extra = HashMap::new();
+    if let Some(Value::String(pagination_key)) =
+        propagated_event.and_then(|event| event.get(INTERNAL_OVERRIDE_PAGINATION_KEY_FIELD))
+    {
+        extra.insert(
+            INTERNAL_OVERRIDE_PAGINATION_KEY_FIELD.to_string(),
+            Value::String(pagination_key.clone()),
+        );
+    }
+    extra
 }
 
 /// Lock-free log queue with batching and HTTP dispatch.

--- a/src/log_queue/queue.rs
+++ b/src/log_queue/queue.rs
@@ -2,7 +2,6 @@ use anyhow::Context;
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::collections::HashMap;
 
 use super::batching::batch_and_serialize_rows;
 use super::config::LogQueueConfig;
@@ -12,10 +11,7 @@ use super::row_key::RowKey;
 use super::worker::LogCommand;
 use crate::error::{BraintrustError, Result};
 use crate::logger::LoginState;
-use crate::types::{
-    LogDestination, Logs3Row, ParentSpanInfo, SpanObjectType, SpanPayload,
-    INTERNAL_OVERRIDE_PAGINATION_KEY_FIELD,
-};
+use crate::types::{LogDestination, Logs3Row, ParentSpanInfo, SpanObjectType, SpanPayload};
 use arc_swap::ArcSwap;
 use crossbeam::channel::{bounded, unbounded, Receiver, Sender, TrySendError};
 use futures::future::join_all;
@@ -382,9 +378,8 @@ impl LogQueueCore {
             tags,
             context,
             span_attributes,
+            extra,
         } = payload;
-
-        let extra = inherited_logs3_extra(span_components.as_ref(), parent_info.as_ref());
 
         if let Some(span_components) = span_components {
             let destination = self
@@ -736,7 +731,6 @@ impl LogQueueCore {
             } = cmd;
 
             let span_components = payload.span_components.clone();
-            let extra = inherited_logs3_extra(span_components.as_ref(), parent_info.as_ref());
 
             let span_id = payload.span_id.clone();
             let destination = match span_components.as_ref() {
@@ -827,7 +821,7 @@ impl LogQueueCore {
                 tags: payload.tags,
                 context: payload.context,
                 span_attributes: payload.span_attributes,
-                extra,
+                extra: payload.extra,
                 created: Utc::now(),
                 xact_id: None,
                 object_delete: None,
@@ -851,32 +845,6 @@ impl LogQueueCore {
             }
         });
     }
-}
-
-fn inherited_logs3_extra(
-    span_components: Option<&crate::span_components::SpanComponents>,
-    parent_info: Option<&ParentSpanInfo>,
-) -> HashMap<String, Value> {
-    let propagated_event = span_components
-        .and_then(|components| components.propagated_event.as_ref())
-        .or_else(|| match parent_info {
-            Some(ParentSpanInfo::FullSpan {
-                propagated_event: Some(propagated_event),
-                ..
-            }) => Some(propagated_event),
-            _ => None,
-        });
-
-    let mut extra = HashMap::new();
-    if let Some(Value::String(pagination_key)) =
-        propagated_event.and_then(|event| event.get(INTERNAL_OVERRIDE_PAGINATION_KEY_FIELD))
-    {
-        extra.insert(
-            INTERNAL_OVERRIDE_PAGINATION_KEY_FIELD.to_string(),
-            Value::String(pagination_key.clone()),
-        );
-    }
-    extra
 }
 
 /// Lock-free log queue with batching and HTTP dispatch.
@@ -1037,6 +1005,7 @@ mod tests {
                 tags: None,
                 context: None,
                 span_attributes: None,
+                extra: std::collections::HashMap::new(),
             },
             parent_info: Some(ParentSpanInfo::Experiment {
                 object_id: "exp-test".to_string(),

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -23,7 +23,7 @@ use crate::http::build_http_client;
 use crate::log_queue::{LogQueue, LogQueueConfig};
 use crate::span::SpanSubmitter;
 use crate::span_components::SpanComponents;
-use crate::types::{ParentSpanInfo, SpanAttributes, SpanObjectType, SpanPayload};
+use crate::types::{ParentSpanInfo, SpanAttributes, SpanEventData, SpanObjectType, SpanPayload};
 
 // 30s covers both quick API calls (login, project registration) and slower batch log uploads.
 // The TypeScript SDK applies no explicit timeout.
@@ -632,15 +632,7 @@ impl BraintrustClient {
         }
 
         let span_id = components.span_id.clone().unwrap_or_else(|| row_id.clone());
-
-        let payload = SpanPayload {
-            row_id,
-            span_id,
-            is_merge: true,
-            span_components: Some(components),
-            org_id,
-            org_name,
-            project_name: None,
+        let mut event_data = SpanEventData {
             input: event.input,
             output: event.output,
             expected: event.expected,
@@ -656,6 +648,31 @@ impl BraintrustClient {
                 purpose: None,
                 extra: HashMap::new(),
             }),
+            extra: HashMap::new(),
+        };
+        if let Some(propagated_event) = components.propagated_event.as_ref() {
+            event_data.apply_propagated_event(propagated_event);
+        }
+
+        let payload = SpanPayload {
+            row_id,
+            span_id,
+            is_merge: true,
+            span_components: Some(components),
+            org_id,
+            org_name,
+            project_name: None,
+            input: event_data.input,
+            output: event_data.output,
+            expected: event_data.expected,
+            error: event_data.error,
+            scores: event_data.scores,
+            metadata: event_data.metadata,
+            metrics: event_data.metrics,
+            tags: event_data.tags,
+            context: event_data.context,
+            span_attributes: event_data.span_attributes,
+            extra: event_data.extra,
         };
 
         self.submit_payload(token, payload, None);

--- a/src/span.rs
+++ b/src/span.rs
@@ -9,7 +9,10 @@ use uuid::Uuid;
 
 use crate::error::Result;
 use crate::span_components::SpanComponents;
-use crate::types::{ParentSpanInfo, SpanAttributes, SpanObjectType, SpanPayload, SpanType};
+use crate::types::{
+    ParentSpanInfo, SpanAttributes, SpanObjectType, SpanPayload, SpanType,
+    INTERNAL_OVERRIDE_PAGINATION_KEY_FIELD,
+};
 
 /// Error type for SpanLog builder validation.
 #[derive(Debug, Clone, PartialEq)]
@@ -624,6 +627,10 @@ impl From<SpanData> for SpanPayload {
 /// This allows parent span metadata to flow down to child spans.
 fn apply_propagated_event_to_span_data(data: &mut SpanData, propagated_event: &Map<String, Value>) {
     for (key, value) in propagated_event {
+        if key == INTERNAL_OVERRIDE_PAGINATION_KEY_FIELD {
+            continue;
+        }
+
         match key.as_str() {
             "input" if data.input.is_none() => {
                 data.input = Some(value.clone());

--- a/src/span.rs
+++ b/src/span.rs
@@ -10,8 +10,7 @@ use uuid::Uuid;
 use crate::error::Result;
 use crate::span_components::SpanComponents;
 use crate::types::{
-    ParentSpanInfo, SpanAttributes, SpanObjectType, SpanPayload, SpanType,
-    INTERNAL_OVERRIDE_PAGINATION_KEY_FIELD,
+    ParentSpanInfo, SpanAttributes, SpanEventData, SpanObjectType, SpanPayload, SpanType,
 };
 
 /// Error type for SpanLog builder validation.
@@ -581,14 +580,7 @@ struct SpanData {
 }
 
 impl From<SpanData> for SpanPayload {
-    fn from(mut data: SpanData) -> Self {
-        // Apply propagated_event if present - merge its fields into the span data
-        if let Some(propagated_event) = data.propagated_event.take() {
-            apply_propagated_event_to_span_data(&mut data, &propagated_event);
-            // Restore the propagated_event after applying it
-            data.propagated_event = Some(propagated_event);
-        }
-
+    fn from(data: SpanData) -> Self {
         let span_attributes = SpanAttributes {
             name: data.name,
             span_type: Some(data.span_type),
@@ -601,14 +593,7 @@ impl From<SpanData> for SpanPayload {
             || span_attributes.span_type.is_some()
             || span_attributes.purpose.is_some();
 
-        Self {
-            row_id: data.row_id,
-            span_id: data.span_id,
-            is_merge: data.has_flushed, // First flush = false (replace), subsequent = true (merge)
-            span_components: None,
-            org_id: data.org_id,
-            org_name: data.org_name,
-            project_name: data.project_name,
+        let mut event_data = SpanEventData {
             input: data.input,
             output: data.output,
             expected: data.expected,
@@ -619,80 +604,32 @@ impl From<SpanData> for SpanPayload {
             tags: (!data.tags.is_empty()).then_some(data.tags),
             context: data.context,
             span_attributes: has_attributes.then_some(span_attributes),
-        }
-    }
-}
+            extra: HashMap::new(),
+        };
 
-/// Apply propagated_event data to SpanData by merging it into the span's fields.
-/// This allows parent span metadata to flow down to child spans.
-fn apply_propagated_event_to_span_data(data: &mut SpanData, propagated_event: &Map<String, Value>) {
-    for (key, value) in propagated_event {
-        if key == INTERNAL_OVERRIDE_PAGINATION_KEY_FIELD {
-            continue;
+        if let Some(propagated_event) = data.propagated_event {
+            event_data.apply_propagated_event(&propagated_event);
         }
 
-        match key.as_str() {
-            "input" if data.input.is_none() => {
-                data.input = Some(value.clone());
-            }
-            "output" if data.output.is_none() => {
-                data.output = Some(value.clone());
-            }
-            "expected" if data.expected.is_none() => {
-                data.expected = Some(value.clone());
-            }
-            "error" if data.error.is_none() => {
-                if let Some(s) = value.as_str() {
-                    data.error = Some(Value::String(s.to_string()));
-                }
-            }
-            "scores" => {
-                if let Some(obj) = value.as_object() {
-                    for (score_key, score_val) in obj {
-                        if let Some(score) = score_val.as_f64() {
-                            data.scores.entry(score_key.clone()).or_insert(score);
-                        }
-                    }
-                }
-            }
-            "metadata" => {
-                if let Some(obj) = value.as_object() {
-                    for (meta_key, meta_val) in obj {
-                        data.metadata
-                            .entry(meta_key.clone())
-                            .or_insert_with(|| meta_val.clone());
-                    }
-                }
-            }
-            "metrics" => {
-                if let Some(obj) = value.as_object() {
-                    for (metric_key, metric_val) in obj {
-                        if let Some(metric) = metric_val.as_f64() {
-                            data.metrics.entry(metric_key.clone()).or_insert(metric);
-                        }
-                    }
-                }
-            }
-            "tags" => {
-                if let Some(arr) = value.as_array() {
-                    for tag_val in arr {
-                        if let Some(tag) = tag_val.as_str() {
-                            if !data.tags.contains(&tag.to_string()) {
-                                data.tags.push(tag.to_string());
-                            }
-                        }
-                    }
-                }
-            }
-            "context" if data.context.is_none() => {
-                data.context = Some(value.clone());
-            }
-            _ => {
-                // Unknown fields go into metadata
-                data.metadata
-                    .entry(key.clone())
-                    .or_insert_with(|| value.clone());
-            }
+        Self {
+            row_id: data.row_id,
+            span_id: data.span_id,
+            is_merge: data.has_flushed, // First flush = false (replace), subsequent = true (merge)
+            span_components: None,
+            org_id: data.org_id,
+            org_name: data.org_name,
+            project_name: data.project_name,
+            input: event_data.input,
+            output: event_data.output,
+            expected: event_data.expected,
+            error: event_data.error,
+            scores: event_data.scores,
+            metadata: event_data.metadata,
+            metrics: event_data.metrics,
+            tags: event_data.tags,
+            context: event_data.context,
+            span_attributes: event_data.span_attributes,
+            extra: event_data.extra,
         }
     }
 }
@@ -881,6 +818,10 @@ mod tests {
         let mut parent_propagated = Map::new();
         parent_propagated.insert("parent_key".to_string(), json!("parent_value"));
         parent_propagated.insert("metadata".to_string(), json!({"inherited": "data"}));
+        parent_propagated.insert(
+            "span_attributes".to_string(),
+            json!({"purpose": "scorer", "skip_realtime": true}),
+        );
 
         let parent_info = ParentSpanInfo::FullSpan {
             object_type: SpanObjectType::ProjectLogs,
@@ -917,9 +858,19 @@ mod tests {
             "Inherited metadata should be present"
         );
         assert_eq!(
-            metadata.get("parent_key").and_then(|v| v.as_str()),
+            captured
+                .payload
+                .extra
+                .get("parent_key")
+                .and_then(|v| v.as_str()),
             Some("parent_value"),
-            "Parent key should be in metadata"
+            "Unknown propagated fields should remain top-level extras"
+        );
+        let span_attributes = captured.payload.span_attributes.as_ref().unwrap();
+        assert_eq!(span_attributes.purpose.as_deref(), Some("scorer"));
+        assert_eq!(
+            span_attributes.extra.get("skip_realtime"),
+            Some(&json!(true))
         );
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -9,6 +9,8 @@ use std::fmt;
 use crate::span_components::SpanComponents;
 
 pub const LOGS_API_VERSION: u8 = 2;
+pub(crate) const INTERNAL_OVERRIDE_PAGINATION_KEY_FIELD: &str =
+    "_bt_internal_override_pagination_key";
 
 /// The type of span object, serialized as its integer representation for wire compatibility.
 #[derive(Debug, Clone, Copy, Serialize_repr, Deserialize_repr, PartialEq, Eq)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -9,8 +9,6 @@ use std::fmt;
 use crate::span_components::SpanComponents;
 
 pub const LOGS_API_VERSION: u8 = 2;
-pub(crate) const INTERNAL_OVERRIDE_PAGINATION_KEY_FIELD: &str =
-    "_bt_internal_override_pagination_key";
 
 /// The type of span object, serialized as its integer representation for wire compatibility.
 #[derive(Debug, Clone, Copy, Serialize_repr, Deserialize_repr, PartialEq, Eq)]
@@ -97,6 +95,141 @@ pub(crate) struct SpanAttributes {
     /// Catch-all for additional fields (passthrough behavior).
     #[serde(flatten, skip_serializing_if = "HashMap::is_empty")]
     pub extra: HashMap<String, Value>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct SpanEventData {
+    pub input: Option<Value>,
+    pub output: Option<Value>,
+    pub expected: Option<Value>,
+    pub error: Option<Value>,
+    pub scores: Option<HashMap<String, f64>>,
+    pub metadata: Option<Map<String, Value>>,
+    pub metrics: Option<HashMap<String, f64>>,
+    pub tags: Option<Vec<String>>,
+    pub context: Option<Value>,
+    pub span_attributes: Option<SpanAttributes>,
+    pub extra: HashMap<String, Value>,
+}
+
+impl SpanEventData {
+    pub fn apply_propagated_event(&mut self, propagated_event: &Map<String, Value>) {
+        let mut event = self.to_event_map();
+        merge_event_maps(&mut event, propagated_event);
+        self.apply_merged_event_map(event);
+    }
+
+    fn to_event_map(&self) -> Map<String, Value> {
+        let mut event = Map::new();
+
+        if let Some(input) = &self.input {
+            event.insert("input".to_string(), input.clone());
+        }
+        if let Some(output) = &self.output {
+            event.insert("output".to_string(), output.clone());
+        }
+        if let Some(expected) = &self.expected {
+            event.insert("expected".to_string(), expected.clone());
+        }
+        if let Some(error) = &self.error {
+            event.insert("error".to_string(), error.clone());
+        }
+        if let Some(scores) = &self.scores {
+            event.insert("scores".to_string(), numeric_map_to_value(scores));
+        }
+        if let Some(metadata) = &self.metadata {
+            event.insert("metadata".to_string(), Value::Object(metadata.clone()));
+        }
+        if let Some(metrics) = &self.metrics {
+            event.insert("metrics".to_string(), numeric_map_to_value(metrics));
+        }
+        if let Some(tags) = &self.tags {
+            event.insert(
+                "tags".to_string(),
+                Value::Array(tags.iter().cloned().map(Value::String).collect()),
+            );
+        }
+        if let Some(context) = &self.context {
+            event.insert("context".to_string(), context.clone());
+        }
+        if let Some(span_attributes) = &self.span_attributes {
+            if let Ok(value) = serde_json::to_value(span_attributes) {
+                event.insert("span_attributes".to_string(), value);
+            }
+        }
+        event.extend(self.extra.clone());
+        event
+    }
+
+    fn apply_merged_event_map(&mut self, mut event: Map<String, Value>) {
+        self.input = event.remove("input");
+        self.output = event.remove("output");
+        self.expected = event.remove("expected");
+        self.error = event.remove("error");
+        self.scores = event.remove("scores").and_then(parse_numeric_map);
+        self.metadata = event.remove("metadata").and_then(|value| match value {
+            Value::Object(map) => Some(map),
+            _ => None,
+        });
+        self.metrics = event.remove("metrics").and_then(parse_numeric_map);
+        self.tags = event.remove("tags").and_then(parse_string_array);
+        self.context = event.remove("context");
+        self.span_attributes = event
+            .remove("span_attributes")
+            .and_then(|value| serde_json::from_value(value).ok());
+        self.extra = HashMap::from_iter(event);
+    }
+}
+
+fn numeric_map_to_value(map: &HashMap<String, f64>) -> Value {
+    Value::Object(Map::from_iter(
+        map.iter()
+            .map(|(key, value)| (key.clone(), Value::from(*value))),
+    ))
+}
+
+fn parse_numeric_map(value: Value) -> Option<HashMap<String, f64>> {
+    match value {
+        Value::Object(map) => Some(HashMap::from_iter(
+            map.into_iter()
+                .filter_map(|(key, value)| value.as_f64().map(|number| (key, number))),
+        )),
+        _ => None,
+    }
+}
+
+fn parse_string_array(value: Value) -> Option<Vec<String>> {
+    match value {
+        Value::Array(values) => Some(
+            values
+                .into_iter()
+                .filter_map(|value| value.as_str().map(ToString::to_string))
+                .collect(),
+        ),
+        _ => None,
+    }
+}
+
+fn merge_event_maps(merge_into: &mut Map<String, Value>, merge_from: &Map<String, Value>) {
+    for (key, merge_from_value) in merge_from {
+        match (merge_into.get_mut(key), merge_from_value) {
+            (Some(Value::Object(merge_into_object)), Value::Object(merge_from_object)) => {
+                merge_event_maps(merge_into_object, merge_from_object);
+            }
+            (Some(Value::Array(merge_into_array)), Value::Array(merge_from_array))
+                if key == "tags" =>
+            {
+                for item in merge_from_array {
+                    if !merge_into_array.iter().any(|existing| existing == item) {
+                        merge_into_array.push(item.clone());
+                    }
+                }
+            }
+            _ => {
+                merge_into.insert(key.clone(), merge_from_value.clone());
+            }
+        }
+    }
 }
 
 /// The `log_id` used for regular (non-playground) log destinations (experiments, project
@@ -338,6 +471,7 @@ pub(crate) struct SpanPayload {
     pub tags: Option<Vec<String>>,
     pub context: Option<Value>,
     pub span_attributes: Option<SpanAttributes>,
+    pub extra: HashMap<String, Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/tests/span_lifecycle.rs
+++ b/tests/span_lifecycle.rs
@@ -320,7 +320,7 @@ async fn client_update_span_with_credentials_includes_exported_span_parents() {
 }
 
 #[tokio::test]
-async fn client_update_span_with_credentials_inherits_exported_pagination_key() {
+async fn client_update_span_with_credentials_inherits_exported_propagated_event() {
     let server = MockServer::start().await;
 
     Mock::given(method("POST"))
@@ -345,10 +345,32 @@ async fn client_update_span_with_credentials_inherits_exported_pagination_key() 
         span_id: Some("span-id".to_string()),
         root_span_id: Some("root-id".to_string()),
         span_parents: Some(vec!["parent-id".to_string()]),
-        propagated_event: Some(Map::from_iter([(
-            INTERNAL_OVERRIDE_PAGINATION_KEY_FIELD.to_string(),
-            json!("p07589456150966042624"),
-        )])),
+        propagated_event: Some(Map::from_iter([
+            (
+                INTERNAL_OVERRIDE_PAGINATION_KEY_FIELD.to_string(),
+                json!("p07589456150966042624"),
+            ),
+            (
+                "_async_scoring_control".to_string(),
+                json!({
+                    "kind": "state_override",
+                    "state": { "status": "disabled" },
+                }),
+            ),
+            (
+                "metadata".to_string(),
+                json!({
+                    "source": "parent",
+                    "nested": { "from_parent": true },
+                }),
+            ),
+            ("metrics".to_string(), json!({ "parent_tokens": 12 })),
+            ("tags".to_string(), json!(["propagated"])),
+            (
+                "span_attributes".to_string(),
+                json!({ "purpose": "scorer", "skip_realtime": true }),
+            ),
+        ])),
     }
     .to_str();
 
@@ -359,6 +381,13 @@ async fn client_update_span_with_credentials_inherits_exported_pagination_key() 
                 "org-id",
                 &exported,
                 SpanLog::builder()
+                    .name("exported-child")
+                    .metadata(Map::from_iter([(
+                        "nested".to_string(),
+                        json!({ "from_child": true }),
+                    )]))
+                    .metric("child_latency_ms", 42.0)
+                    .tag("request")
                     .output(json!({ "status": output }))
                     .build()
                     .expect("build"),
@@ -386,12 +415,45 @@ async fn client_update_span_with_credentials_inherits_exported_pagination_key() 
             row[INTERNAL_OVERRIDE_PAGINATION_KEY_FIELD],
             "p07589456150966042624"
         );
+        assert_eq!(
+            row["_async_scoring_control"],
+            json!({
+                "kind": "state_override",
+                "state": { "status": "disabled" },
+            })
+        );
+        assert_eq!(
+            row["metadata"],
+            json!({
+                "source": "parent",
+                "nested": {
+                    "from_parent": true,
+                    "from_child": true,
+                },
+            })
+        );
+        assert_eq!(
+            row["metrics"],
+            json!({
+                "parent_tokens": 12.0,
+                "child_latency_ms": 42.0,
+            })
+        );
+        assert_eq!(row["tags"], json!(["request", "propagated"]));
+        assert_eq!(
+            row["span_attributes"],
+            json!({
+                "name": "exported-child",
+                "purpose": "scorer",
+                "skip_realtime": true,
+            })
+        );
         assert_eq!(row["span_parents"], json!(["parent-id"]));
     }
 }
 
 #[tokio::test]
-async fn child_span_inherits_parent_pagination_key() {
+async fn child_span_inherits_parent_propagated_event() {
     let server = MockServer::start().await;
 
     Mock::given(method("POST"))
@@ -417,14 +479,31 @@ async fn child_span_inherits_parent_pagination_key() {
             span_id: "parent-span-id".to_string(),
             root_span_id: "root-id".to_string(),
             span_parents: None,
-            propagated_event: Some(Map::from_iter([(
-                INTERNAL_OVERRIDE_PAGINATION_KEY_FIELD.to_string(),
-                json!("p07589456150966042624"),
-            )])),
+            propagated_event: Some(Map::from_iter([
+                (
+                    INTERNAL_OVERRIDE_PAGINATION_KEY_FIELD.to_string(),
+                    json!("p07589456150966042624"),
+                ),
+                (
+                    "_async_scoring_control".to_string(),
+                    json!({
+                        "kind": "state_override",
+                        "state": { "status": "disabled" },
+                    }),
+                ),
+                ("metadata".to_string(), json!({"source": "parent"})),
+                ("tags".to_string(), json!(["propagated"])),
+                (
+                    "span_attributes".to_string(),
+                    json!({ "purpose": "scorer", "skip_realtime": true }),
+                ),
+            ])),
         })
         .build();
     span.log(
         SpanLog::builder()
+            .metadata(Map::from_iter([("child".to_string(), json!(true))]))
+            .tag("request")
             .output(json!({"status": "child"}))
             .build()
             .expect("build"),
@@ -449,6 +528,23 @@ async fn child_span_inherits_parent_pagination_key() {
         row[INTERNAL_OVERRIDE_PAGINATION_KEY_FIELD],
         "p07589456150966042624"
     );
+    assert_eq!(
+        row["_async_scoring_control"],
+        json!({
+            "kind": "state_override",
+            "state": { "status": "disabled" },
+        })
+    );
+    assert_eq!(
+        row["metadata"],
+        json!({
+            "source": "parent",
+            "child": true,
+        })
+    );
+    assert_eq!(row["tags"], json!(["request", "propagated"]));
+    assert_eq!(row["span_attributes"]["purpose"], "scorer");
+    assert_eq!(row["span_attributes"]["skip_realtime"], true);
     assert_eq!(row["span_parents"], json!(["parent-span-id"]));
     assert!(row
         .get("metadata")

--- a/tests/span_lifecycle.rs
+++ b/tests/span_lifecycle.rs
@@ -1,10 +1,12 @@
 use braintrust_sdk_rust::{
-    extract_anthropic_usage, extract_openai_usage, BraintrustClient, SpanComponents, SpanLog,
-    SpanObjectType,
+    extract_anthropic_usage, extract_openai_usage, BraintrustClient, ParentSpanInfo,
+    SpanComponents, SpanLog, SpanObjectType,
 };
 use serde_json::{json, Map, Value};
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const INTERNAL_OVERRIDE_PAGINATION_KEY_FIELD: &str = "_bt_internal_override_pagination_key";
 
 #[tokio::test]
 async fn span_lifecycle_flushes_to_logs_endpoint() {
@@ -315,6 +317,144 @@ async fn client_update_span_with_credentials_includes_exported_span_parents() {
         .and_then(|rows| rows.first())
         .expect("row");
     assert_eq!(row["span_parents"], json!(["parent-id"]));
+}
+
+#[tokio::test]
+async fn client_update_span_with_credentials_inherits_exported_pagination_key() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/logs3"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("{}"))
+        .mount(&server)
+        .await;
+
+    let client = BraintrustClient::builder()
+        .skip_login(true)
+        .api_url(server.uri())
+        .app_url(server.uri())
+        .build()
+        .await
+        .expect("client");
+
+    let exported = SpanComponents {
+        object_type: SpanObjectType::ProjectLogs,
+        object_id: Some("proj-id".to_string()),
+        compute_object_metadata_args: None,
+        row_id: Some("row-id".to_string()),
+        span_id: Some("span-id".to_string()),
+        root_span_id: Some("root-id".to_string()),
+        span_parents: Some(vec!["parent-id".to_string()]),
+        propagated_event: Some(Map::from_iter([(
+            INTERNAL_OVERRIDE_PAGINATION_KEY_FIELD.to_string(),
+            json!("p07589456150966042624"),
+        )])),
+    }
+    .to_str();
+
+    for output in ["first", "second"] {
+        client
+            .update_span_with_credentials(
+                "token",
+                "org-id",
+                &exported,
+                SpanLog::builder()
+                    .output(json!({ "status": output }))
+                    .build()
+                    .expect("build"),
+            )
+            .expect("update");
+        client.flush().await.expect("flush");
+    }
+
+    let logs_requests: Vec<_> = server
+        .received_requests()
+        .await
+        .unwrap()
+        .into_iter()
+        .filter(|request| request.url.path() == "/logs3")
+        .collect();
+    assert_eq!(logs_requests.len(), 2);
+
+    for request in logs_requests {
+        let body: Value = serde_json::from_slice(&request.body).expect("json body");
+        let row = body["rows"]
+            .as_array()
+            .and_then(|rows| rows.first())
+            .expect("row");
+        assert_eq!(
+            row[INTERNAL_OVERRIDE_PAGINATION_KEY_FIELD],
+            "p07589456150966042624"
+        );
+        assert_eq!(row["span_parents"], json!(["parent-id"]));
+    }
+}
+
+#[tokio::test]
+async fn child_span_inherits_parent_pagination_key() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/logs3"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("{}"))
+        .mount(&server)
+        .await;
+
+    let client = BraintrustClient::builder()
+        .skip_login(true)
+        .api_url(server.uri())
+        .app_url(server.uri())
+        .build()
+        .await
+        .expect("client");
+
+    let span = client
+        .span_builder_with_credentials("token", "org-id")
+        .parent_info(ParentSpanInfo::FullSpan {
+            object_type: SpanObjectType::ProjectLogs,
+            object_id: Some("proj-id".to_string()),
+            compute_object_metadata_args: None,
+            span_id: "parent-span-id".to_string(),
+            root_span_id: "root-id".to_string(),
+            span_parents: None,
+            propagated_event: Some(Map::from_iter([(
+                INTERNAL_OVERRIDE_PAGINATION_KEY_FIELD.to_string(),
+                json!("p07589456150966042624"),
+            )])),
+        })
+        .build();
+    span.log(
+        SpanLog::builder()
+            .output(json!({"status": "child"}))
+            .build()
+            .expect("build"),
+    );
+    client.flush().await.expect("flush");
+
+    let logs_requests: Vec<_> = server
+        .received_requests()
+        .await
+        .unwrap()
+        .into_iter()
+        .filter(|request| request.url.path() == "/logs3")
+        .collect();
+    assert_eq!(logs_requests.len(), 1);
+
+    let body: Value = serde_json::from_slice(&logs_requests[0].body).expect("json body");
+    let row = body["rows"]
+        .as_array()
+        .and_then(|rows| rows.first())
+        .expect("row");
+    assert_eq!(
+        row[INTERNAL_OVERRIDE_PAGINATION_KEY_FIELD],
+        "p07589456150966042624"
+    );
+    assert_eq!(row["span_parents"], json!(["parent-span-id"]));
+    assert!(row
+        .get("metadata")
+        .and_then(Value::as_object)
+        .and_then(|metadata| metadata.get(INTERNAL_OVERRIDE_PAGINATION_KEY_FIELD))
+        .is_none());
 }
 
 #[tokio::test]


### PR DESCRIPTION
The other SDKs allow you to write override params that will get propagated to every span. Support that behavior in Rust too.